### PR TITLE
Update register.py: Allow 200 response code

### DIFF
--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -71,7 +71,7 @@ def register_client(
             **custom_options,
         )
 
-        if resp.status_code != 200 and resp.status_code != 202:
+        if resp.status_code not in {200, 202}:
             log_resp_info(resp)
             LOGGER.warning(
                 "Unleash Client registration failed due to unexpected HTTP status code: %s",

--- a/UnleashClient/api/register.py
+++ b/UnleashClient/api/register.py
@@ -71,7 +71,7 @@ def register_client(
             **custom_options,
         )
 
-        if resp.status_code != 202:
+        if resp.status_code != 200 and resp.status_code != 202:
             log_resp_info(resp)
             LOGGER.warning(
                 "Unleash Client registration failed due to unexpected HTTP status code: %s",


### PR DESCRIPTION
# Description

Allow 200 response code to pass registration.

Without this, a Python UnleashClient cannot register appropriately:

```
from UnleashClient import UnleashClient

client = UnleashClient(
        url="https://gitlab.com/api/v4/feature_flags/unleash/123",
        app_name="ci",
        instance_id="abcde")

client.initialize_client()

print(client.is_enabled("dummy_flag"))
```

Testing:


Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created a small UnleashClient(...) script, called initialize_client(), and checked it passes.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
